### PR TITLE
Initialise the servo pin map and set servo pin mode

### DIFF
--- a/arduino/esp32/esp32.ino
+++ b/arduino/esp32/esp32.ino
@@ -333,7 +333,7 @@ void setup() {
     states[i].reportAnalog = 0;
     states[i].reportDigital = 0;
     states[i].ledcChannel = 255; //max because zero is a valid channel
-
+    servoPinMap[i] = 255; // initialise servo pin map states
 
 //   if(IS_PIN_DIGITAL(i) && !IS_PIN_ANALOG(i)){
 //      pinMode(i, OUTPUT);
@@ -551,6 +551,7 @@ void setPinMode(byte pin, int mode)
           // pass -1 for min and max pulse values to use default values set
           // by Servo library
           attachServo(pin, -1, -1);
+          states[pin].mode = mode;
         }
       break;
     case PIN_MODE_I2C:


### PR DESCRIPTION
Create an initial state for the `servoPinMap` tests correctly. Also save the state of the pin being used when `pinMode` is set to `PIN_MODE_SERVO` 

With this done, servos work with standard J5 calls.